### PR TITLE
Ignore secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There's also a [fzf](https://github.com/junegunn/fzf) wrapper for selecting the 
 It's also possible to ignore tracking the clipboard for a specific window class.
 
 For example, to ignore tracking the clipboard for KeePassXC
-add the following line to `~/.config/wayland-clipboard-ignore`:
+add the following line to `~/.config/wl-clipboard-history/ignore`:
 
     org.keepassxc.KeePassXC
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ To use with [sway](https://github.com/swaywm/sway) add the following to your con
 
 There's also a [fzf](https://github.com/junegunn/fzf) wrapper for selecting the contents with a [TUI](https://github.com/janza/wl-clipboard-history/blob/master/contrib/fzf-wrapper).
 
+It's also possible to ignore tracking the clipboard for a specific window class.
+
+For example, to ignore tracking the clipboard for KeePassXC
+add the following line to `~/.config/wayland-clipboard-ignore`:
+
+    org.keepassxc.KeePassXC
+
 ### TODO
 
 - [ ] Add support to delete entries from the history (eg. secrets)

--- a/wl-clipboard-history
+++ b/wl-clipboard-history
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 clipboard_file="$HOME/.clipboard.sqlite"
-clipboard_ignore_file="$HOME/.config/wayland-clipboard-ignore"
+clipboard_ignore_file="$HOME/.config/wl-clipboard-history/ignore"
 
 query () {
     echo "$1" | sqlite3 -separator "," "$clipboard_file"

--- a/wl-clipboard-history
+++ b/wl-clipboard-history
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 clipboard_file="$HOME/.clipboard.sqlite"
+clipboard_ignore_file="$HOME/.config/wayland-clipboard-ignore"
 
 query () {
     echo "$1" | sqlite3 -separator "," "$clipboard_file"
@@ -31,6 +32,11 @@ helpusage () {
 }
 
 if [ $# = 0 ]; then
+   case $XDG_CURRENT_DESKTOP in
+      Hyprland)
+	 [ ! $(hyprctl -j activewindow | jq -r '.class' | xargs -I _ grep --count "_" $clipboard_ignore_file) = 0 ] && exit 0
+	 ;;
+   esac
    contents="$(< /dev/stdin sed "s/'/''/g")"
    if [ "$contents" = "" ]; then
       helpusage

--- a/wl-clipboard-history
+++ b/wl-clipboard-history
@@ -34,7 +34,7 @@ helpusage () {
 if [ $# = 0 ]; then
    case $XDG_CURRENT_DESKTOP in
       Hyprland)
-	 [ ! $(hyprctl -j activewindow | jq -r '.class' | xargs -I _ grep --count "_" $clipboard_ignore_file) = 0 ] && exit 0
+	 [ ! $(hyprctl -j activewindow | jq -r '.class' | xargs -I _ grep --count '_' $clipboard_ignore_file) = 0 ] && exit 0
 	 ;;
    esac
    contents="$(< /dev/stdin sed "s/'/''/g")"

--- a/wl-clipboard-history
+++ b/wl-clipboard-history
@@ -36,6 +36,7 @@ if [ $# = 0 ]; then
       Hyprland)
 	 [ ! $(hyprctl -j activewindow | jq -r '.class' | xargs -I _ grep --count '_' $clipboard_ignore_file) = 0 ] && exit 0
 	 ;;
+	 # TODO: Add cases for other wayland compositors
    esac
    contents="$(< /dev/stdin sed "s/'/''/g")"
    if [ "$contents" = "" ]; then

--- a/wl-clipboard-history
+++ b/wl-clipboard-history
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -euo pipefail
 
 clipboard_file="$HOME/.clipboard.sqlite"


### PR DESCRIPTION
# Ignoring secrets

## How this pull request works

The basic idea, is to have a file that contains window classes, one entry per line, to ignore saving the clipboard into the sqlite database.

When the wl-clipboard-history is tracking clipboard changes through the command

```sh
wl-paste -w wl-clipboard-history
```

And every time it calls wl-clipboard-history without arguments, the script obtains the currently active window and checks against the `~/.config/wl-clipboard-history/ignore` file and count how many times is inside the file.

If the count is different than zero, aka the currently active window is defined in the ignore configuration file, then we exit the wl-clipboard-history to not save to the file:

```sh
case $XDG_CURRENT_DESKTOP in
      Hyprland)
	[ ! $(hyprctl -j activewindow | jq -r '.class' | xargs -I _ grep --count '_' $clipboard_ignore_file) = 0 ] && exit 0
	;;
	# TODO: Add cases for other wayland compositors
   esac
```

## Improvements

For now, it only works for the Hyprland compositor.
But to add to other wayland compositor is simple as adding more case statements like:

```sh
case $XDG_CURRENT_DESKTOP in
      Hyprland)
	[ ! $(hyprctl -j activewindow | jq -r '.class' | xargs -I _ grep --count '_' $clipboard_ignore_file) = 0 ] && exit 0
	;;
	sway)
        [ ! $(get currently active window for sway | xargs -I _ grep --count '_' $clipboard_ignore_file) = 0 ] && exit 0
        ;;
   esac
```